### PR TITLE
refactor!: Computation functions are now renamed to `compute` and `computeIsolate`

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -15,7 +15,7 @@ command:
       async: ^2.11.0
       flutter:
         sdk: flutter
-      flutter_hooks: ^0.20.1
+      flutter_hooks: ^0.20.3
       integral_isolates: ^0.4.1
       meta: ^1.9.1
     dev_dependencies:

--- a/packages/integral_isolates/example/main.dart
+++ b/packages/integral_isolates/example/main.dart
@@ -22,7 +22,7 @@ void main() async {
       const Duration(milliseconds: 100),
       () => threadSleepComputation(1),
     ),
-    isolated.isolate(leibnizPi, 500000000),
+    isolated.compute(leibnizPi, 500000000),
     Future.delayed(
       const Duration(milliseconds: 100),
       () => threadSleepComputation(2),

--- a/packages/integral_isolates/lib/src/backpressure/backpressure_strategy.dart
+++ b/packages/integral_isolates/lib/src/backpressure/backpressure_strategy.dart
@@ -43,8 +43,8 @@ abstract class BackpressureConfiguration<Q, R> {
   Future<void> handleResponse(StreamQueue<dynamic> isolateToMainPort);
 }
 
-/// Job queue item for use with the [StatefulIsolate.isolate] and
-/// [TailoredStatefulIsolate.isolate] functions.
+/// Job queue item for use with the [StatefulIsolate.compute] and
+/// [TailoredStatefulIsolate.compute] functions.
 @internal
 class FutureBackpressureConfiguration<Q, R>
     extends BackpressureConfiguration<Q, R> {
@@ -84,8 +84,8 @@ class FutureBackpressureConfiguration<Q, R>
   }
 }
 
-/// Job queue item for use with the [StatefulIsolate.isolateStream] and
-/// [TailoredStatefulIsolate.isolateStream] functions.
+/// Job queue item for use with the [StatefulIsolate.computeStream] and
+/// [TailoredStatefulIsolate.computeStream] functions.
 @internal
 class StreamBackpressureConfiguration<Q, R>
     extends BackpressureConfiguration<Q, R> {

--- a/packages/integral_isolates/lib/src/integral_isolates.dart
+++ b/packages/integral_isolates/lib/src/integral_isolates.dart
@@ -2,14 +2,6 @@ import 'dart:async';
 
 import 'package:integral_isolates/integral_isolates.dart';
 
-@Deprecated('Use StatefulIsolate directly instead')
-// ignore: public_member_api_docs
-class Isolated extends StatefulIsolate {
-  // ignore: public_member_api_docs
-  @Deprecated('Use StatefulIsolate directly instead')
-  Isolated({super.backpressureStrategy, super.autoInit});
-}
-
 /// Signature for the callback passed to [StatefulIsolate.compute].
 ///
 /// Instances of [IsolateCallback] must be functions that can be sent to an

--- a/packages/integral_isolates/lib/src/integral_isolates.dart
+++ b/packages/integral_isolates/lib/src/integral_isolates.dart
@@ -10,7 +10,7 @@ class Isolated extends StatefulIsolate {
   Isolated({super.backpressureStrategy, super.autoInit});
 }
 
-/// Signature for the callback passed to [StatefulIsolate.isolate].
+/// Signature for the callback passed to [StatefulIsolate.compute].
 ///
 /// Instances of [IsolateCallback] must be functions that can be sent to an
 /// isolate.
@@ -20,7 +20,7 @@ class Isolated extends StatefulIsolate {
 /// from the official Flutter documentation.
 typedef IsolateCallback<Q, R> = FutureOr<R> Function(Q message);
 
-/// Signature for the callback passed to [StatefulIsolate.isolateStream].
+/// Signature for the callback passed to [StatefulIsolate.computeStream].
 ///
 /// Instances of [IsolateStream] must be functions that can be sent to an
 /// isolate.

--- a/packages/integral_isolates/lib/src/stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/stateful_isolate.dart
@@ -28,10 +28,10 @@ typedef IsolateStreamComputeImpl = Future<R> Function<Q, R>(
 
 /// Interface for exposing the [compute] function for a [StatefulIsolate].
 ///
-/// Useful for when wrapping the functionality and just want to expose the
+/// Useful when wrapping the functionality and just want to expose the
 /// computation functions.
 sealed class IsolateGetter {
-  /// The computation function, a function used the same way as Flutter's
+  /// The compute function, used in the same way as Flutter's
   /// compute function, but for a long lived isolate.
   Future<R> compute<Q, R>(
     IsolateCallback<Q, R> callback,
@@ -61,7 +61,7 @@ sealed class IsolateGetter {
 /// Using [backpressureStrategy], you can decide how to handle the case when too
 /// many calls to the isolate are made for it to handle in time.
 ///
-/// Usage of the [compute] function is used the same way as the compute function
+/// The [compute] function is used the same way as the compute function
 /// in the Flutter library.
 ///
 /// The following code is similar to the example from Flutter's compute

--- a/packages/integral_isolates/lib/src/stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/stateful_isolate.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 /// Data type of the implementation of the computation function.
 ///
 /// Can be used as data type for the computation function, for example when
-/// returning the [StatefulIsolate.isolate] as a return type of a function.
+/// returning the [StatefulIsolate.compute] as a return type of a function.
 typedef IsolateComputeImpl = Future<R> Function<Q, R>(
   IsolateCallback<Q, R> callback,
   Q message, {
@@ -19,35 +19,36 @@ typedef IsolateComputeImpl = Future<R> Function<Q, R>(
 /// Data type of the implementation of the stream function.
 ///
 /// Can be used as data type for the stream function, for example when returning
-/// the [StatefulIsolate.isolateStream] as a return type of a function.
+/// the [StatefulIsolate.computeStream] as a return type of a function.
 typedef IsolateStreamComputeImpl = Future<R> Function<Q, R>(
   IsolateStream<Q, R> callback,
   Q message, {
   String? debugLabel,
 });
 
-/// Interface for exposing the [isolate] function for a [StatefulIsolate].
+/// Interface for exposing the [compute] function for a [StatefulIsolate].
 ///
 /// Useful for when wrapping the functionality and just want to expose the
-/// computation function.
+/// computation functions.
 sealed class IsolateGetter {
   /// The computation function, a function used the same way as Flutter's
   /// compute function, but for a long lived isolate.
-  Future<R> isolate<Q, R>(
+  Future<R> compute<Q, R>(
     IsolateCallback<Q, R> callback,
     Q message, {
     String? debugLabel,
   });
 
+  // TODO(lohnn): this documentation is incorrect
   /// The computation function, a function used the same way as Flutter's
   /// compute function, but for a long lived isolate.
   ///
-  /// Very similar to the [isolate] function, but instead of returning a
+  /// Very similar to the [compute] function, but instead of returning a
   /// [Future], a [Stream] is returned to allow for a response in multiple
   /// parts. Every stream event will be sent individually through from the
   /// isolate.
   @experimental
-  Stream<R> isolateStream<Q, R>(
+  Stream<R> computeStream<Q, R>(
     IsolateStream<Q, R> callback,
     Q message, {
     String? debugLabel,
@@ -60,7 +61,7 @@ sealed class IsolateGetter {
 /// Using [backpressureStrategy], you can decide how to handle the case when too
 /// many calls to the isolate are made for it to handle in time.
 ///
-/// Usage of the [isolate] function is used the same way as the compute function
+/// Usage of the [compute] function is used the same way as the compute function
 /// in the Flutter library.
 ///
 /// The following code is similar to the example from Flutter's compute
@@ -69,12 +70,11 @@ sealed class IsolateGetter {
 /// ```dart
 /// void main() async {
 ///   final statefulIsolate = StatefulIsolate();
-///   final computation = statefulIsolate.isolate;
-///   print(await computation(_isPrime, 7));
-///   print(await computation(_isPrime, 42));
-///   print(await computation(_isPrime, 50));
-///   print(await computation(_parseBool, false));
-///   print(await computation(_isPrime, 70));
+///   print(await statefulIsolate.compute(_isPrime, 7));
+///   print(await statefulIsolate.compute(_isPrime, 42));
+///   print(await statefulIsolate.compute(_isPrime, 50));
+///   print(await statefulIsolate.compute(_parseBool, false));
+///   print(await statefulIsolate.compute(_isPrime, 70));
 ///   statefulIsolate.dispose();
 /// }
 ///
@@ -125,7 +125,7 @@ class StatefulIsolate with IsolateBase implements IsolateGetter {
   /// long running thread and allows running in a pure Dart environment.
   @override
   @mustCallSuper
-  Future<R> isolate<Q, R>(
+  Future<R> compute<Q, R>(
     IsolateCallback<Q, R> callback,
     Q message, {
     String? debugLabel,
@@ -148,7 +148,7 @@ class StatefulIsolate with IsolateBase implements IsolateGetter {
 
   @experimental
   @override
-  Stream<R> isolateStream<Q, R>(
+  Stream<R> computeStream<Q, R>(
     IsolateStream<Q, R> callback,
     Q message, {
     String? debugLabel,

--- a/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 /// Data type of the implementation of the computation function.
 ///
 /// Can be used as data type for the computation function, for example when
-/// returning the [TailoredStatefulIsolate.isolate] as a return type of a
+/// returning the [TailoredStatefulIsolate.compute] as a return type of a
 /// function.
 ///
 /// [Q] is the input parameter type.
@@ -21,7 +21,7 @@ typedef TailoredIsolateComputeImpl<Q, R> = Future<R> Function(
   String? debugLabel,
 });
 
-/// Interface for exposing the [isolate] function for a
+/// Interface for exposing the [compute] function for a
 /// [TailoredStatefulIsolate].
 ///
 /// Useful for when wrapping the functionality and just want to expose the
@@ -29,21 +29,22 @@ typedef TailoredIsolateComputeImpl<Q, R> = Future<R> Function(
 sealed class TailoredIsolateGetter<Q, R> {
   /// The computation function, a function used the same way as Flutter's
   /// compute function, but for a long lived isolate.
-  Future<R> isolate(
+  Future<R> compute(
     IsolateCallback<Q, R> callback,
     Q message, {
     String? debugLabel,
   });
 
+  // TODO(lohnn): this documentation is incorrect
   /// The computation function, a function used the same way as Flutter's
   /// compute function, but for a long lived isolate.
   ///
-  /// Very similar to the [isolate] function, but instead of returning a
+  /// Very similar to the [compute] function, but instead of returning a
   /// [Future], a [Stream] is returned to allow for a response in multiple
   /// parts. Every stream event will be sent individually through from the
   /// isolate.
   @experimental
-  Stream<R> isolateStream(
+  Stream<R> computeStream(
     IsolateStream<Q, R> callback,
     Q message, {
     String? debugLabel,
@@ -62,7 +63,7 @@ sealed class TailoredIsolateGetter<Q, R> {
 /// Using [backpressureStrategy], you can decide how to handle the case when too
 /// many calls to the isolate are made for it to handle in time.
 ///
-/// Usage of the [isolate] function is used the same way as the compute function
+/// Usage of the [compute] function is used the same way as the compute function
 /// in the Flutter library.
 ///
 /// The following code is similar to the example from Flutter's compute
@@ -71,11 +72,10 @@ sealed class TailoredIsolateGetter<Q, R> {
 /// ```dart
 /// void main() async {
 ///   final statefulIsolate = TailoredStatefulIsolate<int, bool>();
-///   final computation = statefulIsolate.isolate;
-///   print(await computation(_isPrime, 7));
-///   print(await computation(_isPrime, 42));
-///   print(await computation(_isPrime, 50));
-///   print(await computation(_isPrime, 70));
+///   print(await statefulIsolate.compute(_isPrime, 7));
+///   print(await statefulIsolate.compute(_isPrime, 42));
+///   print(await statefulIsolate.compute(_isPrime, 50));
+///   print(await statefulIsolate.compute(_isPrime, 70));
 ///   statefulIsolate.dispose();
 /// }
 ///
@@ -95,7 +95,7 @@ sealed class TailoredIsolateGetter<Q, R> {
 /// See also:
 ///
 ///  * [StatefulIsolate], to create a long lived isolate that has no predefined
-///  input and output typed, but rather decides type per call to the [isolate]
+///  input and output typed, but rather decides type per call to the [compute]
 ///  function.
 final class TailoredStatefulIsolate<Q, R>
     with IsolateBase<Q, R>
@@ -120,7 +120,7 @@ final class TailoredStatefulIsolate<Q, R>
   }
 
   @override
-  Future<R> isolate(
+  Future<R> compute(
     IsolateCallback<Q, R> callback,
     Q message, {
     String? debugLabel,
@@ -145,7 +145,7 @@ final class TailoredStatefulIsolate<Q, R>
 
   @experimental
   @override
-  Stream<R> isolateStream(
+  Stream<R> computeStream(
     IsolateStream<Q, R> callback,
     Q message, {
     String? debugLabel,

--- a/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
@@ -63,7 +63,7 @@ sealed class TailoredIsolateGetter<Q, R> {
 /// Using [backpressureStrategy], you can decide how to handle the case when too
 /// many calls to the isolate are made for it to handle in time.
 ///
-/// Usage of the [compute] function is used the same way as the compute function
+/// The [compute] function is used the same way as the compute function
 /// in the Flutter library.
 ///
 /// The following code is similar to the example from Flutter's compute

--- a/packages/integral_isolates/test/back_pressure_strategy_test.dart
+++ b/packages/integral_isolates/test/back_pressure_strategy_test.dart
@@ -18,11 +18,11 @@ void main() {
     List iterable() => [1, 'test', 2, 3, 4, 5].toList();
 
     Future<List> runIsolate(BackpressureStrategy strategy) async {
-      final isolated = StatefulIsolate(
+      final isolate = StatefulIsolate(
         backpressureStrategy: strategy,
         autoInit: false,
       );
-      await isolated.init();
+      await isolate.init();
 
       final responses = [];
 
@@ -31,14 +31,14 @@ void main() {
         await Future.delayed(Duration(milliseconds: 50 * delayMultiplier++));
         if (input is String) {
           try {
-            final value = await isolated.isolate(_testFunctionStr, input);
+            final value = await isolate.compute(_testFunctionStr, input);
             responses.add(value);
           } catch (e) {
             // Noop
           }
         } else if (input is int) {
           try {
-            final value = await isolated.isolate(_testFunction, input);
+            final value = await isolate.compute(_testFunction, input);
             responses.add(value);
           } catch (e) {
             // Noop
@@ -50,7 +50,7 @@ void main() {
         for (final number in iterable()) temp(number),
       ]);
 
-      isolated.dispose();
+      isolate.dispose();
 
       return responses;
     }
@@ -62,9 +62,9 @@ void main() {
       await Future.wait([
         for (final input in iterable())
           if (input is String)
-            isolate.isolate(_testFunctionStr, input).then(responses.add)
+            isolate.compute(_testFunctionStr, input).then(responses.add)
           else if (input is int)
-            isolate.isolate(_testFunction, input).then(responses.add),
+            isolate.compute(_testFunction, input).then(responses.add),
       ]);
 
       isolate.dispose();

--- a/packages/integral_isolates/test/backpressure_tailored_isolated_test.dart
+++ b/packages/integral_isolates/test/backpressure_tailored_isolated_test.dart
@@ -15,11 +15,11 @@ void main() {
     Future<List<int>> runIsolate(
       BackpressureStrategy<int, int> strategy,
     ) async {
-      final isolated = TailoredStatefulIsolate<int, int>(
+      final isolate = TailoredStatefulIsolate<int, int>(
         backpressureStrategy: strategy,
         autoInit: false,
       );
-      await isolated.init();
+      await isolate.init();
 
       final responses = <int>[];
 
@@ -27,7 +27,7 @@ void main() {
         await Future.delayed(Duration(milliseconds: 50 * number));
 
         try {
-          final value = await isolated.isolate(_testFunction, number);
+          final value = await isolate.compute(_testFunction, number);
           responses.add(value);
         } catch (e) {
           // Noop
@@ -38,7 +38,7 @@ void main() {
         for (final number in iterable()) temp(number),
       ]);
 
-      isolated.dispose();
+      isolate.dispose();
 
       return responses;
     }
@@ -49,7 +49,7 @@ void main() {
 
       await Future.wait([
         for (final int in iterable())
-          isolate.isolate(_testFunction, int).then(responses.add),
+          isolate.compute(_testFunction, int).then(responses.add),
       ]);
 
       isolate.dispose();
@@ -78,7 +78,7 @@ void main() {
           (oldData, newData) => oldData + newData,
         ),
       );
-      isolate.isolate((message) => message + 2, 2);
+      isolate.compute((message) => message + 2, 2);
 
       final responses = await runIsolate(
         CombineBackPressureStrategy<int, int>((oldData, newData) {

--- a/packages/integral_isolates/test/different_data_types_test.dart
+++ b/packages/integral_isolates/test/different_data_types_test.dart
@@ -5,29 +5,28 @@ import 'package:test/test.dart';
 
 void main() {
   group('Exceptions when queuing jobs should not break upcoming jobs', () {
-    final isolated = StatefulIsolate();
-    final isolate = isolated.isolate;
+    final isolate = StatefulIsolate();
 
     test('Send different data types and expect answers', () async {
       expect(
-        await isolate((number) => number + 2, 1),
+        await isolate.compute((number) => number + 2, 1),
         equals(3),
       );
 
       expect(
-        await isolate((text) => 'prefix: $text', 'testing'),
+        await isolate.compute((text) => 'prefix: $text', 'testing'),
         equals('prefix: testing'),
       );
     });
 
     test('Send unsupported data type should throw exception', () async {
       expect(
-        await isolate((number) => number + 2, 1),
+        await isolate.compute((number) => number + 2, 1),
         equals(3),
       );
 
       expectLater(
-        isolate(
+        isolate.compute(
           print,
           ReceivePort(),
         ),
@@ -35,7 +34,7 @@ void main() {
       );
 
       expect(
-        await isolate((number) => number + 2, 5),
+        await isolate.compute((number) => number + 2, 5),
         equals(7),
       );
     });
@@ -43,12 +42,12 @@ void main() {
     test('Trying to return unsupported data type should throw exception',
         () async {
       expect(
-        await isolate((number) => number + 8, 1),
+        await isolate.compute((number) => number + 8, 1),
         equals(9),
       );
 
       expectLater(
-        isolate(
+        isolate.compute(
           (_) {
             return ReceivePort();
           },
@@ -58,11 +57,11 @@ void main() {
       );
 
       expect(
-        await isolate((number) => number + 5, 25),
+        await isolate.compute((number) => number + 5, 25),
         equals(30),
       );
     });
 
-    tearDownAll(isolated.dispose);
+    tearDownAll(isolate.dispose);
   });
 }

--- a/packages/integral_isolates/test/different_data_types_test.dart
+++ b/packages/integral_isolates/test/different_data_types_test.dart
@@ -27,7 +27,7 @@ void main() {
 
       expectLater(
         isolate.compute(
-          print,
+          (_) {},
           ReceivePort(),
         ),
         throwsArgumentError,

--- a/packages/integral_isolates/test/error_handling_test.dart
+++ b/packages/integral_isolates/test/error_handling_test.dart
@@ -4,18 +4,17 @@ import 'package:test/test.dart';
 void main() {
   group('Lifecycle errors', () {
     test('Throws error when running after dispose', () async {
-      final isolated = TailoredStatefulIsolate<int, int>();
-      final isolate = isolated.isolate;
+      final isolate = TailoredStatefulIsolate<int, int>();
 
       expect(
-        await isolate((number) => number + 2, 1),
+        await isolate.compute((number) => number + 2, 1),
         equals(3),
       );
 
-      isolated.dispose();
+      isolate.dispose();
 
       await expectLater(
-        isolate((number) => number + 2, 5),
+        isolate.compute((number) => number + 2, 5),
         throwsA(isA<IsolateClosedDropException>()),
       );
     });

--- a/packages/integral_isolates/test/huge_dataset_test.dart
+++ b/packages/integral_isolates/test/huge_dataset_test.dart
@@ -17,7 +17,7 @@ void main() {
     group('Just list', () {
       test('Normal case', () async {
         final before = DateTime.now();
-        final sum = await isolate.isolate(_sum, commonList);
+        final sum = await isolate.compute(_sum, commonList);
         print(DateTime.now().difference(before).inMilliseconds);
         expect(sum, 1249999975000000);
       });
@@ -27,7 +27,7 @@ void main() {
       test('Normal case', () async {
         final before = DateTime.now();
         final unmodifiable = List.unmodifiable(commonList);
-        final sum = await isolate.isolate(_sum, unmodifiable.cast<int>());
+        final sum = await isolate.compute(_sum, unmodifiable.cast<int>());
         print(DateTime.now().difference(before).inMilliseconds);
         expect(sum, 1249999975000000);
       });
@@ -37,7 +37,7 @@ void main() {
       test('Normal case', () async {
         final before = DateTime.now();
         final uint8List = Uint32List.fromList(commonList);
-        final sum = await isolate.isolate(_sumUint32List, uint8List);
+        final sum = await isolate.compute(_sumUint32List, uint8List);
         print(DateTime.now().difference(before).inMilliseconds);
         expect(sum, 1249999975000000);
       });
@@ -48,7 +48,7 @@ void main() {
       test('Normal case', () async {
         final before = DateTime.now();
         final transferable = TransferableTypedData.fromList([copiedList]);
-        final sum = await isolate.isolate(_sumTransferable, transferable);
+        final sum = await isolate.compute(_sumTransferable, transferable);
         print(DateTime.now().difference(before).inMilliseconds);
         expect(sum, 1249999975000000);
       });

--- a/packages/integral_isolates/test/isolate_stream_test.dart
+++ b/packages/integral_isolates/test/isolate_stream_test.dart
@@ -9,7 +9,7 @@ void main() {
 
     test('Send different data types and expect answers', () async {
       expectLater(
-        isolate.isolateStream(
+        isolate.computeStream(
           (_) => Stream.fromIterable([2, 3, 5, 42]),
           const Object(),
         ),
@@ -17,7 +17,7 @@ void main() {
       );
 
       expectLater(
-        isolate.isolateStream(
+        isolate.computeStream(
           (_) => Stream.fromFutures([
             Future.delayed(const Duration(milliseconds: 100), () => 'are'),
             Future.value('Async calls'),
@@ -34,7 +34,7 @@ void main() {
 
     test('Send unsupported data type should throw exception', () async {
       expectLater(
-        isolate.isolateStream(
+        isolate.computeStream(
           (_) => Stream.fromIterable([2, 3, 5, 42]),
           const Object(),
         ),
@@ -43,7 +43,7 @@ void main() {
 
       expectLater(
         isolate
-            .isolateStream(
+            .computeStream(
               (_) => Stream.fromIterable([2, 3, 5, 42]),
               ReceivePort(),
             )
@@ -52,7 +52,7 @@ void main() {
       );
 
       expect(
-        await isolate.isolate((number) => number + 2, 5),
+        await isolate.compute((number) => number + 2, 5),
         equals(7),
       );
     });
@@ -60,13 +60,13 @@ void main() {
     test('Trying to return unsupported data type should throw exception',
         () async {
       expectLater(
-        await isolate.isolate((number) => number + 8, 1),
+        await isolate.compute((number) => number + 8, 1),
         equals(9),
       );
 
       expectLater(
         isolate
-            .isolateStream(
+            .computeStream(
               (_) => Stream.value(ReceivePort()),
               'Test String',
             )
@@ -75,7 +75,7 @@ void main() {
       );
 
       expectLater(
-        isolate.isolateStream(
+        isolate.computeStream(
           (_) => Stream.fromIterable([2, 3, 5, 42]),
           const Object(),
         ),
@@ -91,12 +91,12 @@ void main() {
 
     test('Send different data types and expect answers', () async {
       await expectLater(
-        await isolate.isolate((number) => number + 2, 1),
+        await isolate.compute((number) => number + 2, 1),
         equals(3),
       );
 
       await expectLater(
-        isolate.isolateStream(
+        isolate.computeStream(
           (_) => Stream.fromIterable([2, 3, 5, 42]),
           2,
         ),

--- a/packages/use_isolate/lib/src/use_isolate.dart
+++ b/packages/use_isolate/lib/src/use_isolate.dart
@@ -80,5 +80,5 @@ class _IsolateHookState extends HookState<IsolateComputeImpl, _IsolateHook> {
   }
 
   @override
-  IsolateComputeImpl build(BuildContext context) => _isolated.isolate;
+  IsolateComputeImpl build(BuildContext context) => _isolated.compute;
 }

--- a/packages/use_isolate/lib/src/use_tailored_isolate.dart
+++ b/packages/use_isolate/lib/src/use_tailored_isolate.dart
@@ -52,7 +52,7 @@ export 'package:integral_isolates/integral_isolates.dart';
 TailoredIsolateComputeImpl<Q, R> useTailoredIsolate<Q, R>({
   BackpressureStrategy<Q, R>? backpressureStrategy,
 }) {
-  return use(_IsolateHook<Q, R>(backpressureStrategy)).isolate;
+  return use(_IsolateHook<Q, R>(backpressureStrategy)).compute;
 }
 
 class _IsolateHook<Q, R> extends Hook<TailoredStatefulIsolate<Q, R>> {

--- a/packages/use_isolate/pubspec.yaml
+++ b/packages/use_isolate/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.20.1
+  flutter_hooks: ^0.20.3
   integral_isolates: ^0.4.1
 dev_dependencies:
   lint: ^2.1.2


### PR DESCRIPTION
This naming convention should be more familiar and probably be more future proof.