### PR TITLE
feat: Made IsolatGetter and TailoredIsolateGetter publicly overridable again

### DIFF
--- a/packages/integral_isolates/lib/src/stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/stateful_isolate.dart
@@ -30,7 +30,7 @@ typedef IsolateStreamComputeImpl = Future<R> Function<Q, R>(
 ///
 /// Useful when wrapping the functionality and just want to expose the
 /// computation functions.
-sealed class IsolateGetter {
+abstract class IsolateGetter {
   /// The compute function, used in the same way as Flutter's
   /// compute function, but for a long lived isolate.
   Future<R> compute<Q, R>(

--- a/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
+++ b/packages/integral_isolates/lib/src/tailored_stateful_isolate.dart
@@ -26,7 +26,7 @@ typedef TailoredIsolateComputeImpl<Q, R> = Future<R> Function(
 ///
 /// Useful for when wrapping the functionality and just want to expose the
 /// computation function.
-sealed class TailoredIsolateGetter<Q, R> {
+abstract class TailoredIsolateGetter<Q, R> {
   /// The computation function, a function used the same way as Flutter's
   /// compute function, but for a long lived isolate.
   Future<R> compute(


### PR DESCRIPTION
This is useful for the packages that wrap this one, such as flame_isolate.